### PR TITLE
Remove debugging hover zone rectangles

### DIFF
--- a/script.js
+++ b/script.js
@@ -425,6 +425,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const tokenEl = li.querySelector('.player-token') || li;
       const tokenRadiusPx = tokenEl.offsetWidth / 2;
       const angle = parseFloat(li.dataset.angle || '0');
+      const isExpanded = li.dataset.expanded === '1';
       
       // Compute the actual distance from circle center to this token center (runtime radius)
       const container = li.parentElement;
@@ -447,35 +448,140 @@ document.addEventListener('DOMContentLoaded', () => {
       const edgeGap = Math.max(8, tokenRadiusPx * 0.08);
       const spacing = reminderDiameter + edgeGap;
 
-      // Distance from token center to first reminder center
-      const firstReminderOffsetFromToken = tokenRadiusPx + edgeGap + reminderRadius;
       const reminderEls = li.querySelectorAll('.reminders .icon-reminder, .reminders .text-reminder');
-      reminderEls.forEach((el, idx) => {
-          // Target absolute point along the true vector from token center towards circle center
-          const offset = firstReminderOffsetFromToken + idx * spacing;
-          const absX = tokenCenterX + ux * offset;
-          const absY = tokenCenterY + uy * offset;
-          const cx = absX - liRect.left; // center within li
-          const cy = absY - liRect.top;
-          el.style.left = `${cx}px`;
-          el.style.top = `${cy}px`;
-      });
+      
+      // Create or update hover zone to prevent janking
+      let hoverZone = li.querySelector('.reminder-hover-zone');
+      if (!hoverZone) {
+          hoverZone = document.createElement('div');
+          hoverZone.className = 'reminder-hover-zone';
+          li.querySelector('.reminders').appendChild(hoverZone);
+      }
+      
+      if (isExpanded) {
+          // Expanded state: position reminders in radial stack
+          const firstReminderOffsetFromToken = tokenRadiusPx + edgeGap + reminderRadius;
+          reminderEls.forEach((el, idx) => {
+              // Target absolute point along the true vector from token center towards circle center
+              const offset = firstReminderOffsetFromToken + idx * spacing;
+              const absX = tokenCenterX + ux * offset;
+              const absY = tokenCenterY + uy * offset;
+              const cx = absX - liRect.left; // center within li
+              const cy = absY - liRect.top;
+              el.style.left = `${cx}px`;
+              el.style.top = `${cy}px`;
+              el.style.transform = 'translate(-50%, -50%)';
+              el.style.zIndex = '5';
+          });
+          
+          // Position hover zone as a rectangle along the radial line
+          const hoverZoneStart = tokenRadiusPx + edgeGap; // Start from token edge
+          const hoverZoneEnd = tokenRadiusPx + 200; // Extend towards circle center (200px max)
+          const hoverZoneWidth = hoverZoneEnd - hoverZoneStart; // Width along the radial line
+          const hoverZoneHeight = 100; // Height perpendicular to radial line (increased for visibility)
+          
+          // Calculate the center of the hover zone along the radial line
+          const hoverZoneCenterOffset = (hoverZoneStart + hoverZoneEnd) / 2;
+          const hoverZoneCenterX = tokenCenterX + ux * hoverZoneCenterOffset;
+          const hoverZoneCenterY = tokenCenterY + uy * hoverZoneCenterOffset;
+          
+          // Calculate the rotation angle for the hover zone
+          const rotationAngle = Math.atan2(uy, ux) * (180 / Math.PI);
+          
+          // Position the hover zone
+          const hx = hoverZoneCenterX - liRect.left;
+          const hy = hoverZoneCenterY - liRect.top;
+          
+          hoverZone.style.left = `${hx - hoverZoneWidth / 2}px`;
+          hoverZone.style.top = `${hy - hoverZoneHeight / 2}px`;
+          hoverZone.style.width = `${hoverZoneWidth}px`;
+          hoverZone.style.height = `${hoverZoneHeight}px`;
+          hoverZone.style.transform = `translate(0, 0) rotate(${rotationAngle}deg)`;
+          hoverZone.style.transformOrigin = 'center center';
+          
+          // Debug logging
+          console.log(`Hover zone for player ${li.querySelector('.player-name')?.textContent || 'unknown'}:`, {
+              left: hoverZone.style.left,
+              top: hoverZone.style.top,
+              width: hoverZone.style.width,
+              height: hoverZone.style.height,
+              rotation: rotationAngle,
+              isExpanded: isExpanded
+          });
+      } else {
+          // Collapsed state: stack reminders tightly behind the token
+          const collapsedOffset = tokenRadiusPx + edgeGap + reminderRadius;
+          const collapsedSpacing = reminderRadius * 0.3; // Very tight spacing when collapsed
+          
+          reminderEls.forEach((el, idx) => {
+              // Position reminders in a tight stack behind the token
+              const offset = collapsedOffset + (idx * collapsedSpacing);
+              const absX = tokenCenterX + ux * offset;
+              const absY = tokenCenterY + uy * offset;
+              const cx = absX - liRect.left;
+              const cy = absY - liRect.top;
+              el.style.left = `${cx}px`;
+              el.style.top = `${cy}px`;
+              el.style.transform = 'translate(-50%, -50%) scale(0.8)';
+              el.style.zIndex = '2';
+          });
+          
+          // Position hover zone as a rectangle along the radial line (same as expanded state)
+          const hoverZoneStart = tokenRadiusPx + edgeGap; // Start from token edge
+          const hoverZoneEnd = tokenRadiusPx + 200; // Extend towards circle center (200px max)
+          const hoverZoneWidth = hoverZoneEnd - hoverZoneStart; // Width along the radial line
+          const hoverZoneHeight = 100; // Height perpendicular to radial line (increased for visibility)
+          
+          // Calculate the center of the hover zone along the radial line
+          const hoverZoneCenterOffset = (hoverZoneStart + hoverZoneEnd) / 2;
+          const hoverZoneCenterX = tokenCenterX + ux * hoverZoneCenterOffset;
+          const hoverZoneCenterY = tokenCenterY + uy * hoverZoneCenterOffset;
+          
+          // Calculate the rotation angle for the hover zone
+          const rotationAngle = Math.atan2(uy, ux) * (180 / Math.PI);
+          
+          // Position the hover zone
+          const hx = hoverZoneCenterX - liRect.left;
+          const hy = hoverZoneCenterY - liRect.top;
+          
+          hoverZone.style.left = `${hx - hoverZoneWidth / 2}px`;
+          hoverZone.style.top = `${hy - hoverZoneHeight / 2}px`;
+          hoverZone.style.width = `${hoverZoneWidth}px`;
+          hoverZone.style.height = `${hoverZoneHeight}px`;
+          hoverZone.style.transform = `translate(0, 0) rotate(${rotationAngle}deg)`;
+          hoverZone.style.transformOrigin = 'center center';
+      }
 
       const plus = li.querySelector('.reminder-placeholder');
       if (plus) {
-          const PLUS_SHIFT_PX = 20;
-          // Offset from token edge for the plus center measured from token center
-          let offsetFromEdge = tokenRadiusPx + edgeGap + plusRadius;
-          if (count > 0) {
-              offsetFromEdge = tokenRadiusPx + edgeGap + reminderRadius + (count * spacing) + edgeGap + plusRadius;
+          if (isExpanded) {
+              // Expanded state: position plus button at the end of the radial stack
+              const PLUS_SHIFT_PX = 20;
+              let offsetFromEdge = tokenRadiusPx + edgeGap + plusRadius;
+              if (count > 0) {
+                  offsetFromEdge = tokenRadiusPx + edgeGap + reminderRadius + (count * spacing) + edgeGap + plusRadius;
+              }
+              let targetOffset = offsetFromEdge + PLUS_SHIFT_PX;
+              const absPX = tokenCenterX + ux * targetOffset;
+              const absPY = tokenCenterY + uy * targetOffset;
+              const px = absPX - liRect.left;
+              const py = absPY - liRect.top;
+              plus.style.left = `${px}px`;
+              plus.style.top = `${py}px`;
+              plus.style.transform = 'translate(-50%, -50%)';
+              plus.style.zIndex = '6';
+          } else {
+              // Collapsed state: position plus button close to the token
+              const collapsedOffset = tokenRadiusPx + edgeGap + plusRadius;
+              const absPX = tokenCenterX + ux * collapsedOffset;
+              const absPY = tokenCenterY + uy * collapsedOffset;
+              const px = absPX - liRect.left;
+              const py = absPY - liRect.top;
+              plus.style.left = `${px}px`;
+              plus.style.top = `${py}px`;
+              plus.style.transform = 'translate(-50%, -50%) scale(0.9)';
+              plus.style.zIndex = '6';
           }
-          let targetOffset = offsetFromEdge + PLUS_SHIFT_PX; // nudge towards center
-          const absPX = tokenCenterX + ux * targetOffset;
-          const absPY = tokenCenterY + uy * targetOffset;
-          const px = absPX - liRect.left;
-          const py = absPY - liRect.top;
-          plus.style.left = `${px}px`;
-          plus.style.top = `${py}px`;
       }
   }
 

--- a/script.js
+++ b/script.js
@@ -450,14 +450,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const reminderEls = li.querySelectorAll('.reminders .icon-reminder, .reminders .text-reminder');
       
-      // Create or update hover zone to prevent janking
-      let hoverZone = li.querySelector('.reminder-hover-zone');
-      if (!hoverZone) {
-          hoverZone = document.createElement('div');
-          hoverZone.className = 'reminder-hover-zone';
-          li.querySelector('.reminders').appendChild(hoverZone);
-      }
-      
       if (isExpanded) {
           // Expanded state: position reminders in radial stack
           const firstReminderOffsetFromToken = tokenRadiusPx + edgeGap + reminderRadius;
@@ -472,41 +464,6 @@ document.addEventListener('DOMContentLoaded', () => {
               el.style.top = `${cy}px`;
               el.style.transform = 'translate(-50%, -50%)';
               el.style.zIndex = '5';
-          });
-          
-          // Position hover zone as a rectangle along the radial line
-          const hoverZoneStart = tokenRadiusPx + edgeGap; // Start from token edge
-          const hoverZoneEnd = tokenRadiusPx + 200; // Extend towards circle center (200px max)
-          const hoverZoneWidth = hoverZoneEnd - hoverZoneStart; // Width along the radial line
-          const hoverZoneHeight = 100; // Height perpendicular to radial line (increased for visibility)
-          
-          // Calculate the center of the hover zone along the radial line
-          const hoverZoneCenterOffset = (hoverZoneStart + hoverZoneEnd) / 2;
-          const hoverZoneCenterX = tokenCenterX + ux * hoverZoneCenterOffset;
-          const hoverZoneCenterY = tokenCenterY + uy * hoverZoneCenterOffset;
-          
-          // Calculate the rotation angle for the hover zone
-          const rotationAngle = Math.atan2(uy, ux) * (180 / Math.PI);
-          
-          // Position the hover zone
-          const hx = hoverZoneCenterX - liRect.left;
-          const hy = hoverZoneCenterY - liRect.top;
-          
-          hoverZone.style.left = `${hx - hoverZoneWidth / 2}px`;
-          hoverZone.style.top = `${hy - hoverZoneHeight / 2}px`;
-          hoverZone.style.width = `${hoverZoneWidth}px`;
-          hoverZone.style.height = `${hoverZoneHeight}px`;
-          hoverZone.style.transform = `translate(0, 0) rotate(${rotationAngle}deg)`;
-          hoverZone.style.transformOrigin = 'center center';
-          
-          // Debug logging
-          console.log(`Hover zone for player ${li.querySelector('.player-name')?.textContent || 'unknown'}:`, {
-              left: hoverZone.style.left,
-              top: hoverZone.style.top,
-              width: hoverZone.style.width,
-              height: hoverZone.style.height,
-              rotation: rotationAngle,
-              isExpanded: isExpanded
           });
       } else {
           // Collapsed state: stack reminders tightly behind the token
@@ -526,30 +483,7 @@ document.addEventListener('DOMContentLoaded', () => {
               el.style.zIndex = '2';
           });
           
-          // Position hover zone as a rectangle along the radial line (same as expanded state)
-          const hoverZoneStart = tokenRadiusPx + edgeGap; // Start from token edge
-          const hoverZoneEnd = tokenRadiusPx + 200; // Extend towards circle center (200px max)
-          const hoverZoneWidth = hoverZoneEnd - hoverZoneStart; // Width along the radial line
-          const hoverZoneHeight = 100; // Height perpendicular to radial line (increased for visibility)
-          
-          // Calculate the center of the hover zone along the radial line
-          const hoverZoneCenterOffset = (hoverZoneStart + hoverZoneEnd) / 2;
-          const hoverZoneCenterX = tokenCenterX + ux * hoverZoneCenterOffset;
-          const hoverZoneCenterY = tokenCenterY + uy * hoverZoneCenterOffset;
-          
-          // Calculate the rotation angle for the hover zone
-          const rotationAngle = Math.atan2(uy, ux) * (180 / Math.PI);
-          
-          // Position the hover zone
-          const hx = hoverZoneCenterX - liRect.left;
-          const hy = hoverZoneCenterY - liRect.top;
-          
-          hoverZone.style.left = `${hx - hoverZoneWidth / 2}px`;
-          hoverZone.style.top = `${hy - hoverZoneHeight / 2}px`;
-          hoverZone.style.width = `${hoverZoneWidth}px`;
-          hoverZone.style.height = `${hoverZoneHeight}px`;
-          hoverZone.style.transform = `translate(0, 0) rotate(${rotationAngle}deg)`;
-          hoverZone.style.transformOrigin = 'center center';
+
       }
 
       const plus = li.querySelector('.reminder-placeholder');

--- a/styles.css
+++ b/styles.css
@@ -196,6 +196,18 @@ body {
     z-index: 3; /* above plus button */
 }
 
+/* Radial hover zone for reminders - positioned dynamically via JavaScript */
+.reminder-hover-zone {
+    position: absolute;
+    background: transparent;
+    pointer-events: auto;
+    z-index: 1;
+    /* Debug: make hover zone very visible */
+    background: rgba(255, 0, 0, 0.4);
+    border: 2px solid rgba(255, 0, 0, 0.8);
+    box-shadow: 0 0 10px rgba(255, 0, 0, 0.5);
+}
+
 .text-reminder {
     background-image: url('assets/img/token-BqDQdWeO.webp');
     background-size: cover;
@@ -234,8 +246,8 @@ body {
     justify-content: center;
     background-image: url('assets/img/token-BqDQdWeO.webp');
     overflow: visible; /* allow SVG text to overdraw border */
-    z-index: 4; /* ensure above nearby elements */
-    transition: left .18s ease, top .18s ease, transform .18s ease;
+    z-index: 5; /* ensure above hover zone and nearby elements */
+    transition: left 0.3s ease, top 0.3s ease, transform 0.3s ease, z-index 0.3s ease;
 }
 
 .icon-reminder:hover {
@@ -364,7 +376,9 @@ body {
 }
 
 /* Smooth movement for text reminders during expand/collapse */
-.text-reminder { transition: left .18s ease, top .18s ease, transform .18s ease; }
+.text-reminder { 
+    transition: left 0.3s ease, top 0.3s ease, transform 0.3s ease, z-index 0.3s ease; 
+}
 
 .reminder-placeholder {
     position: absolute;
@@ -384,7 +398,7 @@ body {
     box-shadow: 0 2px 8px rgba(0,0,0,0.5);
     border: 2px solid #B8860B;
     transition: all 0.3s ease;
-    z-index: 2; /* below reminders */
+    z-index: 6; /* above hover zone and reminders to ensure clickability */
 }
 
 .reminder-placeholder:hover {

--- a/styles.css
+++ b/styles.css
@@ -81,6 +81,7 @@ body {
     background-repeat: no-repeat;
     background-position: center;
     overflow: visible; /* ensure reminder overlays are not clipped by the token */
+    z-index: 5;
 }
 
 /* Debug: line from token center to circle center */
@@ -125,7 +126,6 @@ body {
 }
 
 .player-token:hover {
-    transform: scale(1.05);
     box-shadow: 
       0 0 30px rgba(212, 175, 55, 0.8),
       inset 0 0 20px rgba(0,0,0,0.3);
@@ -146,7 +146,6 @@ body {
     background: linear-gradient(135deg, rgba(0,0,0,0.9) 0%, rgba(40,40,40,0.9) 100%);
     padding: 0.8vmin 2vmin;
     border-radius: 20px;
-    margin-top: 1.5vmin;
     font-size: 2.2vmin;
     text-align: center;
     color: white;
@@ -156,12 +155,34 @@ body {
     box-shadow: 0 4px 8px rgba(0,0,0,0.5);
     font-weight: bold;
     text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1;
+    transition: all 0.3s ease;
+    opacity: 0.3;
+    pointer-events: auto;
+    filter: blur(0.5px);
 }
 
 .player-name:hover {
     background: linear-gradient(135deg, rgba(40,40,40,0.9) 0%, rgba(60,60,60,0.9) 100%);
     transform: translateY(-2px);
     box-shadow: 0 6px 12px rgba(0,0,0,0.6);
+}
+
+/* Hover effect on the list item to reveal and position the name tag */
+#player-circle li:hover .player-name {
+    opacity: 1;
+    transform: translate(-50%, calc(-50% + var(--token-size) * 0.6));
+    z-index: 10;
+    filter: blur(0px);
+}
+
+/* Ensure the list item has proper positioning for hover effects */
+#player-circle li {
+    position: relative;
 }
 
 .reminders {

--- a/styles.css
+++ b/styles.css
@@ -196,17 +196,7 @@ body {
     z-index: 3; /* above plus button */
 }
 
-/* Radial hover zone for reminders - positioned dynamically via JavaScript */
-.reminder-hover-zone {
-    position: absolute;
-    background: transparent;
-    pointer-events: auto;
-    z-index: 1;
-    /* Debug: make hover zone very visible */
-    background: rgba(255, 0, 0, 0.4);
-    border: 2px solid rgba(255, 0, 0, 0.8);
-    box-shadow: 0 0 10px rgba(255, 0, 0, 0.5);
-}
+
 
 .text-reminder {
     background-image: url('assets/img/token-BqDQdWeO.webp');
@@ -246,7 +236,7 @@ body {
     justify-content: center;
     background-image: url('assets/img/token-BqDQdWeO.webp');
     overflow: visible; /* allow SVG text to overdraw border */
-    z-index: 5; /* ensure above hover zone and nearby elements */
+    z-index: 5; /* ensure above nearby elements */
     transition: left 0.3s ease, top 0.3s ease, transform 0.3s ease, z-index 0.3s ease;
 }
 


### PR DESCRIPTION
This PR removes the red debugging rectangles that were used to visualize hover zones for reminders. These were temporary visual aids during development and are no longer needed in production.