### PR TITLE
feat(ui): sidebar control and reminder token improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,9 @@
           <p>Load a script to see available characters.</p>
         </div>
       </div>
+      <div class="section">
+        <a class="button" href="terms.html">Terms of Use</a>
+      </div>
     </div>
     <div id="sidebar-resizer" aria-label="Resize sidebar" role="separator"></div>
 
@@ -93,9 +96,7 @@
     </div>
   </div>
 
-  <footer style="position: fixed; bottom: 10px; right: 10px; z-index: 1001;">
-    <a href="terms.html" style="color: #9a6bc8; text-decoration: none; background: rgba(0,0,0,0.6); padding: 6px 10px; border-radius: 6px; border: 1px solid #7a4ba8;">Terms of Use</a>
-  </footer>
+  
 
   <script src="script.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
 <body>
   <div id="app">
     <div id="sidebar">
+      <button class="button sidebar-close" id="sidebar-close" aria-label="Close sidebar">Close Sidebar</button>
       <div class="section">
         <h3>Game Setup</h3>
         <div>

--- a/script.js
+++ b/script.js
@@ -39,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const reminderTokenSearch = document.getElementById('reminder-token-search');
   const reminderTokenModalPlayerName = document.getElementById('reminder-token-modal-player-name');
   const sidebarToggleBtn = document.getElementById('sidebar-toggle');
+  const sidebarCloseBtn = document.getElementById('sidebar-close');
 
   let scriptData = null;
   let allRoles = {};
@@ -615,7 +616,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const ux = vx / (runtimeRadius || 1);
       const uy = vy / (runtimeRadius || 1);
 
-      const reminderDiameter = Math.max(56, tokenEl.offsetWidth / 3);
+      const reminderDiameter = Math.max(28, tokenEl.offsetWidth * 0.25);
       const reminderRadius = reminderDiameter / 2;
       const plusRadius = (tokenEl.offsetWidth / 4) / 2; // from CSS: width: token-size/4
       const edgeGap = Math.max(8, tokenRadiusPx * 0.08);
@@ -1058,9 +1059,12 @@ document.addEventListener('DOMContentLoaded', () => {
             { id: 'virgin-noability', image: '/assets/reminders/virgin_g-DfRSMLSj.webp', label: 'No Ability' }
           ];
         }
-        const filter = (reminderTokenSearch && reminderTokenSearch.value || '').toLowerCase();
+         const filter = (reminderTokenSearch && reminderTokenSearch.value || '').toLowerCase();
          // Normalize image paths for gh-pages subpath
          reminderTokens = reminderTokens.map(t => ({ ...t, image: resolveAssetPath(t.image) }));
+         // Put custom option at the top
+         const isCustom = (t) => /custom/i.test(t.label || '') || /custom/i.test(t.id || '');
+         reminderTokens.sort((a, b) => (isCustom(a) === isCustom(b)) ? 0 : (isCustom(a) ? -1 : 1));
          const filtered = reminderTokens.filter(t => (t.label || '').toLowerCase().includes(filter));
         (filtered.length ? filtered : reminderTokens).forEach((token, idx) => {
             const tokenEl = document.createElement('div');
@@ -1301,8 +1305,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const COLLAPSE_KEY = 'sidebarCollapsed';
     const applyCollapsed = (collapsed) => {
       document.body.classList.toggle('sidebar-collapsed', collapsed);
-      // Update button label and aria
-      sidebarToggleBtn.textContent = collapsed ? 'Open Sidebar' : 'Close Sidebar';
+      // Show open button only when collapsed
+      sidebarToggleBtn.textContent = 'Open Sidebar';
+      sidebarToggleBtn.style.display = collapsed ? 'inline-block' : 'none';
       sidebarToggleBtn.setAttribute('aria-pressed', String(!collapsed));
       // Save state
       localStorage.setItem(COLLAPSE_KEY, collapsed ? '1' : '0');
@@ -1313,11 +1318,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const stored = localStorage.getItem(COLLAPSE_KEY);
     const startCollapsed = stored === '1';
     applyCollapsed(startCollapsed);
-    // Toggle handler
+    // Open button (in grimoire)
     sidebarToggleBtn.addEventListener('click', () => {
-      const collapsed = !document.body.classList.contains('sidebar-collapsed');
-      applyCollapsed(collapsed);
+      applyCollapsed(false);
     });
+    // Close button (in sidebar)
+    if (sidebarCloseBtn) {
+      sidebarCloseBtn.addEventListener('click', () => {
+        applyCollapsed(true);
+      });
+    }
   })();
 
   // Restore previous session (script and grimoire)

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,15 @@ body {
   font-size: 14px;
 }
 
+/* Close button inside sidebar header */
+#sidebar .sidebar-close {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: 5;
+  margin: 0 0 10px 0;
+}
+
 @media (hover: none) and (pointer: coarse) {
   .sidebar-toggle {
     padding: 14px 16px;
@@ -226,10 +235,10 @@ body {
     background-size: cover;
     border: 2px solid #D4AF37;
     color: white;
-    width: calc(var(--token-size) / 3);
-    height: calc(var(--token-size) / 3);
-    min-width: 56px;
-    min-height: 56px;
+    width: calc(var(--token-size) * 0.25);
+    height: calc(var(--token-size) * 0.25);
+    min-width: 28px;
+    min-height: 28px;
     border-radius: 50%; /* circular reminder */
     font-size: 1.5vmin;
     display: flex;
@@ -243,10 +252,10 @@ body {
 
 /* icon reminder token that overlaps player token */
 .icon-reminder {
-    width: calc(var(--token-size) / 3);
-    height: calc(var(--token-size) / 3);
-    min-width: 56px;
-    min-height: 56px;
+    width: calc(var(--token-size) * 0.25);
+    height: calc(var(--token-size) * 0.25);
+    min-width: 28px;
+    min-height: 28px;
     border-radius: 50%;
     background-size: cover;
     background-position: center;

--- a/styles.css
+++ b/styles.css
@@ -321,8 +321,8 @@ body {
 .reminder-delete-btn {
   position: absolute;
   left: 50%;
-  top: 10%;
-  transform: translate(-50%, -50%);
+  top: 0;
+  transform: translate(-50%, -110%);
   width: calc(var(--token-size) * 0.0625);
   height: calc(var(--token-size) * 0.0625);
   min-width: 12px;
@@ -344,6 +344,10 @@ body {
 
 .icon-reminder:hover .reminder-delete-btn,
 .text-reminder:hover .reminder-delete-btn { opacity: 1; }
+
+/* Keep delete button clickable even if reminder is not expanded */
+.icon-reminder .reminder-delete-btn,
+.text-reminder .reminder-delete-btn { pointer-events: auto; }
 
 @media (hover: none) and (pointer: coarse) {
   .reminder-delete-btn { opacity: 1; }

--- a/styles.css
+++ b/styles.css
@@ -321,10 +321,12 @@ body {
 .reminder-delete-btn {
   position: absolute;
   left: 50%;
-  top: 50%;
+  top: 10%;
   transform: translate(-50%, -50%);
-  width: 22px;
-  height: 22px;
+  width: calc(var(--token-size) * 0.0625);
+  height: calc(var(--token-size) * 0.0625);
+  min-width: 12px;
+  min-height: 12px;
   border-radius: 50%;
   background: rgba(0,0,0,0.85);
   color: #fff;
@@ -332,10 +334,12 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 10px;
+  line-height: 1;
   opacity: 0;
   transition: opacity .15s ease;
   cursor: pointer;
+  z-index: 7;
 }
 
 .icon-reminder:hover .reminder-delete-btn,


### PR DESCRIPTION
- Move Close Sidebar button into sidebar header; Open button only on grimoire when collapsed
- Scale reminder tokens to ~25% of character token size and reduce minimums to avoid oversized hover areas on mobile
- Prioritize Custom reminder token at the top of selection list