### PR TITLE
Enable offline caching with refresh updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,10 +3,42 @@ if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('./service-worker.js')
       .then(registration => {
         console.log('Service worker registered successfully:', registration);
+        
+        // Check for updates on page load
+        registration.update();
+        
+        // Check for updates periodically (every hour)
+        setInterval(() => {
+          registration.update();
+        }, 60 * 60 * 1000);
+        
+        // Handle service worker updates
+        registration.addEventListener('updatefound', () => {
+          const newWorker = registration.installing;
+          console.log('Service worker update found!');
+          
+          newWorker.addEventListener('statechange', () => {
+            if (newWorker.state === 'activated' && navigator.serviceWorker.controller) {
+              console.log('New service worker activated');
+              // Optionally notify user about the update
+              if (confirm('A new version is available! Reload to update?')) {
+                window.location.reload();
+              }
+            }
+          });
+        });
       })
       .catch(error => {
         console.error('Service worker registration failed:', error);
       });
+  });
+  
+  // Handle controller change (when skipWaiting is called)
+  let refreshing = false;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (refreshing) return;
+    refreshing = true;
+    window.location.reload();
   });
 }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'botc-offline-grimoire-v2';
+const CACHE_NAME = 'botc-offline-grimoire-v3';
 const urlsToCache = [
   './',
   './index.html',
@@ -16,10 +16,24 @@ const urlsToCache = [
   './assets/fontawesome/webfonts/fa-regular-400.woff2',
   './assets/fontawesome/webfonts/fa-brands-400.woff2',
   './assets/img/background4-C7TzDZ7M.webp',
-  './assets/img/token-BqDQdWeO.webp'
+  './assets/img/token-BqDQdWeO.webp',
+  './assets/icons/android-chrome-192x192.png',
+  './assets/icons/android-chrome-512x512.png'
+];
+
+// Files that should always be fetched from network first
+const networkFirstFiles = [
+  'index.html',
+  'styles.css',
+  'script.js',
+  'service-worker.js',
+  'manifest.json'
 ];
 
 self.addEventListener('install', event => {
+  // Skip waiting to activate immediately
+  self.skipWaiting();
+  
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then(cache => {
@@ -39,7 +53,12 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('fetch', event => {
-  // Handle token image requests
+  const url = new URL(event.request.url);
+  const isNetworkFirst = networkFirstFiles.some(file => 
+    url.pathname.endsWith(file) || url.pathname === '/' || url.pathname === '/workspace/'
+  );
+
+  // Handle token image requests - cache first
   if (event.request.url.includes('script.bloodontheclocktower.com/images/icon/') || event.request.url.includes('/assets/token-icons/')) {
     event.respondWith(
       caches.match(event.request)
@@ -67,12 +86,25 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  // Handle tokens.json requests
+  // Handle tokens.json requests - cache first
   if (event.request.url.includes('/tokens.json') || event.request.url.endsWith('tokens.json')) {
     event.respondWith(
       caches.match(event.request)
         .then(response => {
           if (response) {
+            // Try to fetch fresh version in background
+            fetch(event.request)
+              .then(freshResponse => {
+                if (freshResponse.ok) {
+                  const responseClone = freshResponse.clone();
+                  caches.open(CACHE_NAME).then(cache => {
+                    cache.put(event.request, responseClone);
+                    // Cache all token images after successfully caching tokens.json
+                    cacheAllTokenImages();
+                  });
+                }
+              })
+              .catch(() => {});
             return response;
           }
           return fetch(event.request)
@@ -106,7 +138,7 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  // Cache base script JSON files on fetch as well
+  // Cache base script JSON files on fetch as well - cache first
   if (event.request.url.endsWith('Trouble%20Brewing.json') || event.request.url.endsWith('Bad%20Moon%20Rising.json') || event.request.url.endsWith('Sects%20and%20Violets.json')) {
     event.respondWith(
       caches.match(event.request).then(response => {
@@ -123,7 +155,38 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  // Handle other requests
+  // Handle network-first files (HTML, CSS, JS)
+  if (isNetworkFirst) {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          if (response.ok) {
+            const responseClone = response.clone();
+            caches.open(CACHE_NAME).then(cache => {
+              cache.put(event.request, responseClone);
+            });
+          }
+          return response;
+        })
+        .catch(() => {
+          // Fall back to cache if network fails
+          return caches.match(event.request)
+            .then(response => {
+              if (response) {
+                return response;
+              }
+              // Return cached index.html for navigation requests
+              if (event.request.mode === 'navigate') {
+                return caches.match('./index.html');
+              }
+              return null;
+            });
+        })
+    );
+    return;
+  }
+
+  // Handle other requests - cache first
   event.respondWith(
     caches.match(event.request)
       .then(response => {
@@ -202,15 +265,21 @@ async function cacheAllTokenImages() {
 self.addEventListener('activate', event => {
   const cacheWhitelist = [CACHE_NAME];
   event.waitUntil(
-    caches.keys().then(cacheNames => {
-      return Promise.all(
-        cacheNames.map(cacheName => {
-          if (cacheWhitelist.indexOf(cacheName) === -1) {
-            return caches.delete(cacheName);
-          }
-        })
-      );
-    })
+    Promise.all([
+      // Delete old caches
+      caches.keys().then(cacheNames => {
+        return Promise.all(
+          cacheNames.map(cacheName => {
+            if (cacheWhitelist.indexOf(cacheName) === -1) {
+              console.log('Deleting old cache:', cacheName);
+              return caches.delete(cacheName);
+            }
+          })
+        );
+      }),
+      // Take control of all clients immediately
+      self.clients.claim()
+    ])
   );
 });
 

--- a/terms.html
+++ b/terms.html
@@ -55,7 +55,7 @@
   </main>
   <script>
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/service-worker.js').catch(()=>{});
+      navigator.serviceWorker.register('./service-worker.js').catch(()=>{});
     }
   </script>
 </body>


### PR DESCRIPTION
Implement a network-first PWA caching strategy to enable offline use while ensuring updates on refresh, optimized for GitHub Pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-2317afed-bf30-42a9-a860-a32efb61ce69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2317afed-bf30-42a9-a860-a32efb61ce69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

