### PR TITLE
Close sidebar on touch outside click

### DIFF
--- a/script.js
+++ b/script.js
@@ -1624,6 +1624,30 @@ document.addEventListener('DOMContentLoaded', () => {
         applyCollapsed(true);
       });
     }
+    
+    // Add outside click handler for touch devices
+    if (isTouchDevice) {
+      const handleOutsideClick = (event) => {
+        // Check if sidebar is currently open
+        if (document.body.classList.contains('sidebar-collapsed')) {
+          return; // Sidebar is already closed
+        }
+        
+        // Check if click is outside sidebar and sidebar resizer
+        const clickedInSidebar = sidebarEl.contains(event.target);
+        const clickedOnResizer = sidebarResizer && sidebarResizer.contains(event.target);
+        const clickedOnToggleButton = sidebarToggleBtn.contains(event.target);
+        
+        if (!clickedInSidebar && !clickedOnResizer && !clickedOnToggleButton) {
+          // Click is outside sidebar, close it
+          applyCollapsed(true);
+        }
+      };
+      
+      // Add both click and touchstart event listeners for better touch support
+      document.addEventListener('click', handleOutsideClick, true);
+      document.addEventListener('touchstart', handleOutsideClick, { passive: true, capture: true });
+    }
   })();
 
   // Restore previous session (script and grimoire)

--- a/styles.css
+++ b/styles.css
@@ -511,6 +511,7 @@ body {
   overflow-y: auto;
   border-right: 2px solid #D4AF37;
   box-shadow: 6px 0 24px rgba(0,0,0,0.6);
+  transition: flex 0.3s ease, width 0.3s ease, min-width 0.3s ease, padding 0.3s ease, border 0.3s ease;
 }
 
 /* Sidebar sections with better spacing */


### PR DESCRIPTION
Enable closing the sidebar by clicking outside of it on touch devices to improve mobile user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a55e265-dcbe-4285-996e-0117ed5d80b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a55e265-dcbe-4285-996e-0117ed5d80b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

